### PR TITLE
Added repository_dispatch to sa-workflows.yml

### DIFF
--- a/.github/workflows/sa-workflows.yml
+++ b/.github/workflows/sa-workflows.yml
@@ -8,6 +8,16 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  repository_dispatch:
+    types: [ deploy_success ]
+    inputs:
+      environment:
+        description: 'Environment to run tests against'
+        required: true
+        default: 'banner'
+        type: choice
+        options:
+          - banner
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
This allows triggering the test workflow without needing to know the workflow id, which gives us more flexibility.

I was lazy and just copied the `input` from the `workflow_dispatch` event, although in theory it's possible to set up [reusable workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows).